### PR TITLE
minor changes to moves.js, added promotion to queens to setDestCell function

### DIFF
--- a/main.js
+++ b/main.js
@@ -123,7 +123,18 @@ function redraw() {
 }
 
 function setDestCell() {
-  state.board[state.dest[0]][state.dest[1]] = state.board[state.origin[0]][state.origin[1]]
+  //Check if white pawn has reached final rank, if so promote to queen
+  if(state.dest[0]==0 && state.board[state.origin[0]][state.origin[1]] ==='w-p'){
+    state.board[state.dest[0]][state.dest[1]]  = 'w-q'  
+  }
+  //Same check for black pawn
+  else if (state.dest[0]==7 && state.board[state.origin[0]][state.origin[1]] ==='b-p'){
+    state.board[state.dest[0]][state.dest[1]] = 'b-q'
+  }
+  //Else, set destination cell as original piece
+  else{
+    state.board[state.dest[0]][state.dest[1]] = state.board[state.origin[0]][state.origin[1]]
+  }
 }
 
 function clearOriginCell() {

--- a/moves.js
+++ b/moves.js
@@ -142,6 +142,5 @@ function validWhitePawnMove(){
   if(state.origin[0]== 6 && state.dest[0] == 4 && state.dest[1] === state.origin[1] && state.board[state.dest[0]][state.dest[1]]==='empty'){
     return true;
   }
-  
   return false
 }


### PR DESCRIPTION
Added promotions to the setDestCell function. Behaves as before, except when pawns of either colour reach the final rank. Here it now changes them to queens (note this is a simplification of the actual rules of chess, but I don't think it's that important!).